### PR TITLE
Jobs appear on company show page

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -6,7 +6,7 @@ class Company < ApplicationRecord
   def self.top_interests
     joins(:jobs)
     .group(:id)
-    .order("avg(level_of_interest) DESC")
+    .order('avg(level_of_interest) DESC')
     .limit(3)
   end
 

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -14,6 +14,12 @@
 
 <% end %>
 
+<h1>Jobs</h1>
+
+<% @company.jobs.each do |job| %>
+  <%= job.title %>
+<% end %>
+
 <ul><% @company.contacts.each do |contact| %>
   <li>Name: <%= contact.name %></li>
   <li>Email: <%= contact.email %></li>

--- a/spec/features/companies/user_sees_one_company_spec.rb
+++ b/spec/features/companies/user_sees_one_company_spec.rb
@@ -3,11 +3,41 @@ require 'rails_helper'
 describe 'User sees one company' do
   scenario 'a user sees a company' do
     company = Company.create!(name: 'ESPN')
-    company.jobs.create!(title: 'Developer', level_of_interest: 90, city: 'Denver')
+    company.jobs.create!(title: 'Developer',
+                         level_of_interest: 90,
+                         city: 'Denver')
 
     visit company_path(company)
 
     expect(current_path).to eq(company_path(company))
     expect(page).to have_content('Contacts')
+    expect(page).to have_content('Jobs')
+  end
+
+  scenario 'user sees all the companys contacts' do
+    company = Company.create!(name: 'ESPN')
+    company.jobs.create!(title: 'Developer',
+                         level_of_interest: 90,
+                         city: 'Denver')
+    contact = company.contacts.create(name: 'Barry Allen',
+                                     position: 'Speedster',
+                                     email: 'ballen@domain.com')
+
+    visit company_path(company)
+
+    expect(page).to have_content(contact.name)
+    expect(page).to have_content(contact.position)
+    expect(page).to have_content(contact.email)
+  end
+
+  scenario 'user sees all the companys jobs' do
+    company = Company.create!(name: 'ESPN')
+    job = company.jobs.create!(title: 'Developer',
+                               level_of_interest: 90,
+                               city: 'Denver')
+
+    visit company_path(company)
+
+    expect(page).to have_content(job.title)
   end
 end


### PR DESCRIPTION
Was going to add more routes for companies/1/jobs but didn't because it's bad design for the specs / wireframe / github instructions.

Added jobs to show on company show page.